### PR TITLE
mod header icon-less links design

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,11 +20,11 @@
         <p class="header">kanazawarb.github.com</p>
 
         <ul>
-          <li style="text-align: center"><a class="buttons" href="./meetup/" style="background-image: none; padding-left: 2px">meetup</a></li>
-          <li><a class="buttons github" href="https://github.com/kanazawarb">GitHub Profile</a></li>
-          <li><a class="buttons" href="https://twitter.com/kanazawarb">Twitter</a></li>
-          <li><a class="buttons" href="https://www.facebook.com/kanazawarb">Facebook</a></li>
-          <li><a class="buttons" href="https://plus.google.com/112019730992271991381" rel="publisher">Google+</a></li>
+          <li class="no-icon"><a class="buttons" href="./meetup/">meetup</a></li>
+          <li><a class="buttithub" href="https://github.com/kanazawarb">GitHub Profile</a></li>
+          <li class="no-icon"><a class="buttons" href="https://twitter.com/kanazawarb">Twitter</a></li>
+          <li class="no-icon"><a class="buttons" href="https://www.facebook.com/kanazawarb">Facebook</a></li>
+          <li class="no-icon"><a class="buttons" href="https://plus.google.com/112019730992271991381" rel="publisher">Google+</a></li>
         </ul>
 
       </header>

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -287,6 +287,10 @@ header li:hover {
   background: linear-gradient(top, #C3001D 0%,#950119 100%);
 }
 
+header li.no-icon {
+  text-align: center;
+}
+
 a.buttons {
 	-webkit-font-smoothing: antialiased;
 	background: url(../images/arrow-down.png) no-repeat;
@@ -303,6 +307,11 @@ a.github {
 a.buttons:hover {
 	color: #fff;
 	text-decoration: none;
+}
+
+header li.no-icon a.buttons {
+  background-image: none;
+  padding: 2px 2px 2px 2px;
 }
 
 


### PR DESCRIPTION
header li 周りのデザインを再度改修。
元々 @wtnabe が 'meetup' のリンクに適用してたものを横展開した。

Jekyll の theme まわりの仕組みを把握していないので、あまり css に手を入れたく無かったのだけど、現状だと「ファイルのダウンロード」みたいな事になっているので、取り急ぎ css をいじることで対応してある。
もし css を自動生成するような仕組みなのだとしたら、この辺のスタイルを css から切り出して html に埋め込む必要があると思う。

前述の通り css は、なるべく既存値をいじらない方針で書いた。
なので、設計的にはダサイと思う。デフォルト値変えたい。
