### PR TITLE
Update styles.css: make header absolute instead of fixed

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -209,7 +209,7 @@ header {
 	color: #FDFDFB;
   width:170px;
   float:left;
-  position:fixed;
+  position:absolute;
 	border: 1px solid #000;
 	-webkit-border-top-right-radius: 4px;
 	-webkit-border-bottom-right-radius: 4px;


### PR DESCRIPTION
文字が大きめのブラウザだと下の方の項目が見えなくて押せないので、メニューの固定をfixedからabsoluteにしました。
応急処置とはいえ見やすくなると思うのですが、いかがでしょうか。
