### PR TITLE
fix header link visibility w/ narrow screen

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -371,6 +371,13 @@ footer {
     right:130px;
     top:84px;
   }
+  header li:nth-of-type(1n) {
+    display: none;
+  }
+  header li:nth-child(1),
+  header li:nth-child(2) {
+    display: list-item;
+  }
 }
 
 @media print, screen and (max-width: 720px) {


### PR DESCRIPTION
twitter やら facebook へのリンクがはみ出してたので、狭いときは非表示に。
meetup と github へのリンクだけ残る形。
